### PR TITLE
Add a space in the view custom extension pack command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("extension-manager.extension.view", async () => {
       vscode.commands.executeCommand(
         "workbench.extensions.search",
-        '@installed @category:"Custom Extension"'
+        '@installed @category:"Custom Extension" '
       );
     })
   );


### PR DESCRIPTION
So I don't need to manually type a space every time:
<img width="492" height="379" alt="image" src="https://github.com/user-attachments/assets/f3383154-68e5-430f-896b-f85f1870b507" />
